### PR TITLE
Add functionality allowing to fail during socket creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ func main() {
 	err := statsdclient.CreateSocket()
 	if nil != err {
 		log.Println(err)
-		os.Exit(1)
+		// optional exit, socket creation will be retried during lifecycle of the client
+		//os.Exit(1)
 	}
 	interval := time.Second * 2 // aggregate stats and flush every 2 seconds
 	stats := statsd.NewStatsdBuffer(interval, statsdclient)

--- a/event/precisiontiming_test.go
+++ b/event/precisiontiming_test.go
@@ -13,7 +13,7 @@ func TestPrecisionTimingUpdate(t *testing.T) {
 	e1.Update(e2)
 	e1.Update(e3)
 
-	expected := []string{"test.count:3|a", "test.avg:0.005000|ms", "test.min:0.003000|ms", "test.max:0.007000|ms"}
+	expected := []string{"test.count:3|c", "test.avg:0.005000|ms", "test.min:0.003000|ms", "test.max:0.007000|ms"}
 	actual := e1.Stats()
 	if !reflect.DeepEqual(expected, actual) {
 		t.Errorf("did not receive all metrics: Expected: %T %v, Actual: %T %v ", expected, expected, actual, actual)

--- a/event/timing_test.go
+++ b/event/timing_test.go
@@ -12,7 +12,7 @@ func TestTimingUpdate(t *testing.T) {
 	e1.Update(e2)
 	e1.Update(e3)
 
-	expected := []string{"test.count:3|a", "test.avg:5|ms", "test.min:3|ms", "test.max:7|ms"}
+	expected := []string{"test.count:3|c", "test.avg:5|ms", "test.min:3|ms", "test.max:7|ms"}
 	actual := e1.Stats()
 	if !reflect.DeepEqual(expected, actual) {
 		t.Errorf("did not receive all metrics: Expected: %T %v, Actual: %T %v ", expected, expected, actual, actual)


### PR DESCRIPTION
### Overview
The current implementation of `statsd` library is "sensitive" to Dial (TCP/UDP) errors during socket creation.

### Changes
Add functionality allowing clients to continue on socket creation errors, with subsequent connection retries.