### PR TITLE
Allows control over reconnection/logging, fixes resource leak and golint errors

### DIFF
--- a/client.go
+++ b/client.go
@@ -55,11 +55,11 @@ type StatsdClient struct {
 // a StatsdClient instance
 type ConfigurationFunc func(*StatsdClient)
 
-// AutoReconnect returns a ConfigurationFunc that causes the StatsdClient to
+// WithReconnectInterval returns a ConfigurationFunc that causes the StatsdClient to
 // automatically recreate its underlying connection on the specified interval.
 // If no reconnection interval is supplied via this configuration func, or the
 // supplied interval is invalid, the default of 30 seconds will be used.
-func AutoReconnect(interval time.Duration) ConfigurationFunc {
+func WithReconnectInterval(interval time.Duration) ConfigurationFunc {
 	return func(client *StatsdClient) {
 		if interval > 0 {
 			client.reconnectTicker = time.NewTicker(interval)
@@ -67,9 +67,9 @@ func AutoReconnect(interval time.Duration) ConfigurationFunc {
 	}
 }
 
-// UseLogger returns a ConfigurationFunc that makes the StatsdClient use the specified Logger
+// WithLogger returns a ConfigurationFunc that makes the StatsdClient use the specified Logger
 // implementation, rather than the default implementation.
-func UseLogger(logger Logger) ConfigurationFunc {
+func WithLogger(logger Logger) ConfigurationFunc {
 	return func(client *StatsdClient) {
 		client.Logger = logger
 	}

--- a/client.go
+++ b/client.go
@@ -86,7 +86,7 @@ func NewStatsdClient(addr string, prefix string, options ...ConfigurationFunc) *
 			for range client.reconnectTicker.C {
 				err := client.Reconnect()
 				if err != nil {
-					fmt.Println(err)
+					client.Logger.Println(err)
 				}
 			}
 		}()
@@ -103,10 +103,10 @@ func (c *StatsdClient) String() string {
 func (c *StatsdClient) Reconnect() error {
 	var err error
 	if c.conn_type == "udp" {
-		fmt.Println("creating new udp")
+		c.Logger.Println("creating new udp")
 		err = c.CreateSocket()
 	} else if c.conn_type == "tcp" {
-		fmt.Println("creating new tcp")
+		c.Logger.Println("creating new tcp")
 		err = c.CreateTCPSocket()
 	} else if c.conn_type == "" {
 		return fmt.Errorf("No socket created, cannot identify connection type")

--- a/client.go
+++ b/client.go
@@ -121,8 +121,6 @@ func (c *StatsdClient) String() string {
 // stats. Any existing socket is closed before opening a new socket. Any error
 // encountered while closing an existing socket is logged, but not returned.
 func (c *StatsdClient) Reconnect() error {
-	var err error
-
 	// close any existing socket before creating a new one
 	if c.conn != nil {
 		if err := c.conn.Close(); err != nil {
@@ -130,19 +128,16 @@ func (c *StatsdClient) Reconnect() error {
 		}
 	}
 
-	if c.connType == "udp" {
+	switch c.connType {
+	case "udp":
 		c.Logger.Println("creating new udp socket")
-		err = c.CreateSocket()
-	} else if c.connType == "tcp" {
+		return c.CreateSocket()
+	case "tcp":
 		c.Logger.Println("creating new tcp socket")
-		err = c.CreateTCPSocket()
-	} else if c.connType == "" {
+		return c.CreateTCPSocket()
+	default:
 		return fmt.Errorf("no socket created, cannot identify connection type")
 	}
-	if err != nil {
-		return err
-	}
-	return nil
 }
 
 // CreateSocket creates a UDP connection to a StatsD server

--- a/client.go
+++ b/client.go
@@ -100,6 +100,7 @@ func (c *StatsdClient) String() string {
 	return c.addr
 }
 
+// Reconnect causes the client to re-create its underlying socket used to send stats
 func (c *StatsdClient) Reconnect() error {
 	var err error
 	if c.connType == "udp" {

--- a/client.go
+++ b/client.go
@@ -113,13 +113,13 @@ func (c *StatsdClient) String() string {
 func (c *StatsdClient) Reconnect() error {
 	var err error
 	if c.connType == "udp" {
-		c.Logger.Println("creating new udp")
+		c.Logger.Println("creating new udp socket")
 		err = c.CreateSocket()
 	} else if c.connType == "tcp" {
-		c.Logger.Println("creating new tcp")
+		c.Logger.Println("creating new tcp socket")
 		err = c.CreateTCPSocket()
 	} else if c.connType == "" {
-		return fmt.Errorf("No socket created, cannot identify connection type")
+		return fmt.Errorf("no socket created, cannot identify connection type")
 	}
 	if err != nil {
 		return err

--- a/client.go
+++ b/client.go
@@ -51,29 +51,27 @@ type StatsdClient struct {
 
 // ConfigurationFunc is a typedef for a function that configures some aspect of
 // a StatsdClient instance
-type ConfigurationFunc func(*StatsdClient) error
+type ConfigurationFunc func(*StatsdClient)
 
 // AutoReconnect returns a ConfigurationFunc that causes the StatsdClient to automatically
 // recreate its underlying connection on the specified interval.
 func AutoReconnect(interval time.Duration) ConfigurationFunc {
-	return func(client *StatsdClient) error {
+	return func(client *StatsdClient) {
 		client.reconnectTicker = time.NewTicker(interval)
-		return nil
 	}
 }
 
 // UseLogger returns a ConfigurationFunc that makes the StatsdClient use the specified Logger
 // implementation, rather than the default implementation.
 func UseLogger(logger Logger) ConfigurationFunc {
-	return func(client *StatsdClient) error {
+	return func(client *StatsdClient) {
 		client.Logger = logger
-		return nil
 	}
 }
 
 // NewStatsdClient is a factory func that creates a StatsdClient that sends to
 // the configured address and prefixes all stats with the given prefix name.
-func NewStatsdClient(addr string, prefix string, options ...ConfigurationFunc) (*StatsdClient, error) {
+func NewStatsdClient(addr string, prefix string, options ...ConfigurationFunc) *StatsdClient {
 	// allow %HOST% in the prefix string
 	prefix = strings.Replace(prefix, "%HOST%", Hostname, 1)
 	client := &StatsdClient{
@@ -84,9 +82,7 @@ func NewStatsdClient(addr string, prefix string, options ...ConfigurationFunc) (
 
 	// apply all the configuration functions
 	for _, opt := range options {
-		if err := opt(client); err != nil {
-			return nil, err
-		}
+		opt(client)
 	}
 
 	// set some defaults, if necessary
@@ -105,7 +101,7 @@ func NewStatsdClient(addr string, prefix string, options ...ConfigurationFunc) (
 		}()
 	}
 
-	return client, nil
+	return client
 }
 
 // String returns the StatsD server address

--- a/client.go
+++ b/client.go
@@ -62,6 +62,15 @@ func AutoReconnect(interval time.Duration) ConfigurationFunc {
 	}
 }
 
+// UseLogger returns a ConfigurationFunc that makes the StatsdClient use the specified Logger
+// implementation, rather than the default implementation.
+func UseLogger(logger Logger) ConfigurationFunc {
+	return func(client *StatsdClient) error {
+		client.Logger = logger
+		return nil
+	}
+}
+
 // NewStatsdClient is a factory func that creates a StatsdClient that sends to
 // the configured address and prefixes all stats with the given prefix name.
 func NewStatsdClient(addr string, prefix string, options ...ConfigurationFunc) (*StatsdClient, error) {
@@ -70,7 +79,6 @@ func NewStatsdClient(addr string, prefix string, options ...ConfigurationFunc) (
 	client := &StatsdClient{
 		addr:           addr,
 		prefix:         prefix,
-		Logger:         log.New(os.Stdout, "[StatsdClient] ", log.Ldate|log.Ltime),
 		eventStringTpl: "%s%s:%s",
 	}
 
@@ -79,6 +87,11 @@ func NewStatsdClient(addr string, prefix string, options ...ConfigurationFunc) (
 		if err := opt(client); err != nil {
 			return nil, err
 		}
+	}
+
+	// set some defaults, if necessary
+	if client.Logger == nil {
+		client.Logger = log.New(os.Stdout, "[StatsdClient] ", log.Ldate|log.Ltime)
 	}
 
 	if client.reconnectTicker != nil {

--- a/client.go
+++ b/client.go
@@ -57,7 +57,9 @@ type ConfigurationFunc func(*StatsdClient)
 // recreate its underlying connection on the specified interval.
 func AutoReconnect(interval time.Duration) ConfigurationFunc {
 	return func(client *StatsdClient) {
-		client.reconnectTicker = time.NewTicker(interval)
+		if interval > 0 {
+			client.reconnectTicker = time.NewTicker(interval)
+		}
 	}
 }
 

--- a/client.go
+++ b/client.go
@@ -24,7 +24,7 @@ type Logger interface {
 //  func init() {
 //   statsd.UDPPayloadSize = 16 * 1024
 //  }
-var UDPPayloadSize int = 512
+var UDPPayloadSize = 512
 
 // Hostname is exported so clients can set it to something different than the default
 var Hostname string
@@ -269,7 +269,7 @@ func (c *StatsdClient) SendEvents(events map[string]event.Event) error {
 	}
 
 	var n int
-	var stats []string = make([]string, 0)
+	var stats = make([]string, 0)
 
 	for _, e := range events {
 		for _, stat := range e.Stats() {

--- a/client.go
+++ b/client.go
@@ -45,7 +45,7 @@ type StatsdClient struct {
 	prefix          string
 	eventStringTpl  string
 	Logger          Logger
-	conn_type       string
+	connType        string
 	reconnectTicker *time.Ticker
 }
 
@@ -102,13 +102,13 @@ func (c *StatsdClient) String() string {
 
 func (c *StatsdClient) Reconnect() error {
 	var err error
-	if c.conn_type == "udp" {
+	if c.connType == "udp" {
 		c.Logger.Println("creating new udp")
 		err = c.CreateSocket()
-	} else if c.conn_type == "tcp" {
+	} else if c.connType == "tcp" {
 		c.Logger.Println("creating new tcp")
 		err = c.CreateTCPSocket()
-	} else if c.conn_type == "" {
+	} else if c.connType == "" {
 		return fmt.Errorf("No socket created, cannot identify connection type")
 	}
 	if err != nil {
@@ -124,7 +124,7 @@ func (c *StatsdClient) CreateSocket() error {
 		return err
 	}
 	c.conn = conn
-	c.conn_type = "udp"
+	c.connType = "udp"
 	return nil
 }
 
@@ -135,7 +135,7 @@ func (c *StatsdClient) CreateTCPSocket() error {
 		return err
 	}
 	c.conn = conn
-	c.conn_type = "tcp"
+	c.connType = "tcp"
 	c.eventStringTpl = "%s%s:%s\n"
 	return nil
 }

--- a/client.go
+++ b/client.go
@@ -64,7 +64,7 @@ func AutoReconnect(interval time.Duration) ConfigurationFunc {
 
 // NewStatsdClient is a factory func that creates a StatsdClient that sends to
 // the configured address and prefixes all stats with the given prefix name.
-func NewStatsdClient(addr string, prefix string, options ...ConfigurationFunc) *StatsdClient {
+func NewStatsdClient(addr string, prefix string, options ...ConfigurationFunc) (*StatsdClient, error) {
 	// allow %HOST% in the prefix string
 	prefix = strings.Replace(prefix, "%HOST%", Hostname, 1)
 	client := &StatsdClient{
@@ -92,7 +92,7 @@ func NewStatsdClient(addr string, prefix string, options ...ConfigurationFunc) *
 		}()
 	}
 
-	return client
+	return client, nil
 }
 
 // String returns the StatsD server address

--- a/client_test.go
+++ b/client_test.go
@@ -133,7 +133,7 @@ func TestReconnecting(t *testing.T) {
 	prefix := "test."
 
 	client := NewStatsdClient(udpAddr.String(), prefix)
-	client.reconnect_ticker = time.NewTicker(10 * time.Millisecond)
+	client.reconnectTicker = time.NewTicker(10 * time.Millisecond)
 
 	ch := make(chan string, 0)
 

--- a/client_test.go
+++ b/client_test.go
@@ -132,8 +132,7 @@ func TestReconnecting(t *testing.T) {
 
 	prefix := "test."
 
-	client := NewStatsdClient(udpAddr.String(), prefix)
-	client.reconnectTicker = time.NewTicker(10 * time.Millisecond)
+	client := NewStatsdClient(udpAddr.String(), prefix, AutoReconnect(10*time.Millisecond))
 
 	ch := make(chan string, 0)
 

--- a/client_test.go
+++ b/client_test.go
@@ -141,7 +141,7 @@ func TestReconnecting(t *testing.T) {
 
 	prefix := "test."
 
-	client := NewStatsdClient(udpAddr.String(), prefix, AutoReconnect(10*time.Millisecond))
+	client := NewStatsdClient(udpAddr.String(), prefix, WithReconnectInterval(10*time.Millisecond))
 
 	ch := make(chan string, 0)
 


### PR DESCRIPTION
[GAT-22303](https://jira.dp.hbo.com/browse/GAT-22303)

### Overview
This PR makes a few changes to the statsd client:

- it gives the user of the client the ability to configure the reconnect behavior
- it gives the user of the client the ability to control the logging (or lack thereof)

Additionally, it fixes a potential resource leak by ensuring that any existing socket is closed (thereby freeing the underlying file descriptor) before reconnecting with a new socket.

Finally, it performs some code hygiene by fixing some findings from the [golint tool](https://github.com/golang/lint). 

### Details

#### new configuration options

The new `WithReconnectInterval` function allows a user of this package to specify the desired reconnect behavior by providing a `time.Duration` that specifies how often to reconnect.  

##### Example:
```
NewStatsdClient("localhost:8125", "foo", WithReconnectInterval(10 * time.Second))
```

Similarly, the `WithLogger` function allows a user to control which logger implementation to use when the client needs to log a message.  The previous usages of `fmt.Printf` were replaced with calls to the configured logger, so that the consuming application has the ability to control if/how statsd client messages get logged.

##### Example:
To silence any client log messages, a "null logger" implementation can be used:
```
type nullLogger struct{}
func(nl nullLogger) Println(v ...interface{}) {}

NewStatsdClient("localhost:8125", "foo", WithLogger(nullLogger{}))
```
To use any other desired logger, simply pass an instance that conforms to the package's `Logger` interface.

#### closing existing sockets
As @jsongHBO pointed out, the `Reconnect` method that was added in a previous PR didn't attempt to close an existing socket before creating a new one.  This had the potential to leak file descriptors over time.

#### golint fixes

The `golint` fixes were all straightforward refactoring that should be performed on any Go codebase. 
 Some of the specific `golint` error messages being addressed are:

`client.go:48:2: don't use underscores in Go names; struct field conn_type should be connType`
`client.go:103:1: exported method StatsdClient.Reconnect should have comment or be unexported`
`client.go:27:20: should omit type int from declaration of var UDPPayloadSize; it will be inferred from the right-hand side`
`client.go:272:12: should omit type []string from declaration of var stats; it will be inferred from the right-hand side`

