### PR TITLE
Add test for client Timing method

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -294,12 +294,16 @@ func TestSocketCloseOnReconnect(t *testing.T) {
 	c := NewStatsdClient("127.0.0.1:1201", "test")
 	originalConn := &MockNetConn{} // mock connection
 	c.conn = originalConn
+	c.connType = udpSocket
 
 	if originalConn.Closed {
 		t.Errorf("expected socket not to be closed, but it was")
 	}
 
-	c.Reconnect()
+	err := c.Reconnect()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if !originalConn.Closed {
 		t.Errorf("expected previous socket to be closed, but it wasn't")

--- a/client_test.go
+++ b/client_test.go
@@ -68,7 +68,7 @@ func newLocalListenerUDP(t *testing.T) (*net.UDPConn, *net.UDPAddr) {
 	return ln, udpAddr
 }
 
-func TestTiming(t *testing.T) {
+func TestTimingTCP(t *testing.T) {
 	addr, ln := newLocalListenerTCP(t)
 	defer ln.Close()
 


### PR DESCRIPTION
The test `TestSocketCloseOnReconnect` fails to catch errors returned by the Reconnect method.

Also, added a new test to validate the functionality of the Timing method.
